### PR TITLE
Add badges and metadata for better discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # oracle-clinical-trial-data-mgmt-on-oci
+
+![Oracle](https://img.shields.io/badge/Oracle-F80000?style=for-the-badge&logo=oracle&logoColor=white)
+![Oracle Cloud](https://img.shields.io/badge/Oracle%20Cloud-F80000?style=for-the-badge&logo=oracle&logoColor=white)
+![OCI](https://img.shields.io/badge/OCI-Autonomous%20Database-F80000?style=for-the-badge&logo=oracle&logoColor=white)
+![SQL](https://img.shields.io/badge/SQL-Developer-4479A1?style=for-the-badge&logo=oracle&logoColor=white)
+![Clinical Trials](https://img.shields.io/badge/Clinical%20Trials-Data%20Management-0066CC?style=for-the-badge)
+![Database](https://img.shields.io/badge/Database-Oracle%20Database-F80000?style=for-the-badge&logo=oracle&logoColor=white)
+
 Implementation of a cloud solution on Oracle Cloud Infrastructure (OCI) to support clinical trial data capture and reporting, inspired by Oracle Clinical / Remote Data Capture.
+
+**Oracle Cloud Infrastructure (OCI) | Clinical Trial Data Management | Oracle Autonomous Database | Clinical Data Management (CDM) | CTMS | Clinical Research Database | Regulatory Compliance | Data Integrity | IBM Oracle Cloud Solutions**
+
+## Metadata & Keywords
+
+**Technologies:** Oracle Cloud Infrastructure (OCI), Oracle Autonomous Database, Oracle SQL Developer, Oracle Database, SQL, PL/SQL, Clinical Data Management
+
+**Domains:** Clinical Trials, Clinical Data Management (CDM), Electronic Data Capture (EDC), Clinical Research, Regulatory Reporting, Lab Data Management, Site Management, Subject Tracking
+
+**Use Cases:** Clinical Trial Data Management, CTMS (Clinical Trial Management System), Oracle Clinical, Remote Data Capture, Clinical Database Design, Regulatory Compliance, Data Integrity
+
+**Target Audience:** Clinical Data Managers, Oracle Cloud Architects, Database Administrators, Clinical Research Professionals, IBM Oracle Consultants, Oracle Cloud Implementation Teams
+
+**Recommended GitHub Topics:** `oracle`, `oracle-cloud`, `oci`, `oracle-autonomous-database`, `clinical-trials`, `clinical-data-management`, `cdm`, `ctms`, `clinical-research`, `oracle-sql`, `database-design`, `clinical-database`, `regulatory-compliance`, `data-integrity`, `ibm`, `oracle-cloud-infrastructure`, `sql-developer`, `clinical-trial-management`, `edc`, `electronic-data-capture`
+
+> 💡 **Tip:** Add these topics to your repository via GitHub's web interface (Settings → Topics) to improve discoverability in searches by IBM, Oracle Cloud professionals, and Clinical Data Managers.
 
 ## Screenshots
 


### PR DESCRIPTION
- Added Oracle, OCI, SQL, and Clinical Trials badges using shields.io
- Added comprehensive metadata section with keywords for:
  * Technologies (OCI, Oracle Autonomous Database, SQL Developer)
  * Domains (Clinical Trials, CDM, EDC, Clinical Research)
  * Use Cases (CTMS, Oracle Clinical, Regulatory Compliance)
  * Target Audience (Clinical Data Managers, IBM Oracle Consultants)
- Added recommended GitHub topics list for repository discoverability
- Enhanced description with SEO-friendly keywords for IBM, Oracle Cloud, and Clinical Data Managers